### PR TITLE
Removed addons that cause misconfiguration

### DIFF
--- a/app.json
+++ b/app.json
@@ -10,14 +10,7 @@
         }
     },
     "formation": {},
-    "addons": [
-        "mongolab",
-        "mongolab",
-        "mongolab",
-        "mongolab",
-        "mongolab",
-        "mongolab"
-    ],
+    "addons": [],
     "buildpacks": [
         {
             "url": "heroku/nodejs"


### PR DESCRIPTION
This should get rid of the addons that were causing the addition of config vars that were overriding the ones pointing the app to our mlab instances