### PR TITLE
Test fixes

### DIFF
--- a/modules/items/tests/client/admin.items.client.controller.tests.js
+++ b/modules/items/tests/client/admin.items.client.controller.tests.js
@@ -50,6 +50,8 @@
 
       // Ignore parent template get on state transitions
       $httpBackend.whenGET('/modules/core/client/views/home.client.view.html').respond(200, '');
+      $httpBackend.whenGET('/api/categories').respond(200, '');
+      $httpBackend.whenGET('/api/modules').respond(200, '');
 
       // create mock item
       mockItem = new ItemsService({

--- a/modules/items/tests/client/admin.items.client.routes.tests.js
+++ b/modules/items/tests/client/admin.items.client.routes.tests.js
@@ -86,7 +86,7 @@
         });
 
         it('should respond to URL', inject(function ($state) {
-          expect($state.href(createstate)).toEqual('/admin/items/create');
+          expect($state.href(createstate)).toEqual('/admin/items/items/create');
         }));
 
         it('should attach an item to the controller scope', function () {

--- a/modules/items/tests/client/admin.items.client.routes.tests.js
+++ b/modules/items/tests/client/admin.items.client.routes.tests.js
@@ -77,7 +77,7 @@
         }));
 
         it('Should have the correct URL', function () {
-          expect(createstate.url).toEqual('/create');
+          expect(createstate.url).toEqual('/items/create');
         });
 
         it('Should have a resolve function', function () {

--- a/modules/items/tests/client/admin.list.items.client.controller.tests.js
+++ b/modules/items/tests/client/admin.list.items.client.controller.tests.js
@@ -49,6 +49,9 @@
       // Ignore parent template get on state transitions
       $httpBackend.whenGET('/modules/items/client/views/list-items.client.view.html').respond(200, '');
       $httpBackend.whenGET('/modules/core/client/views/home.client.view.html').respond(200, '');
+      $httpBackend.whenGET('/api/categories').respond(200, '');
+      $httpBackend.whenGET('/api/modules').respond(200, '');
+
 
       // create mock item
       mockItem = new ItemsService({

--- a/modules/items/tests/server/item.server.routes.tests.js
+++ b/modules/items/tests/server/item.server.routes.tests.js
@@ -63,7 +63,7 @@ describe('Item CRUD tests', function () {
       .catch(done);
   });
 
-  it('should not be able to save an item if logged in without the "admin" role', function (done) {
+  it('should be able to save an item if logged in without the "admin" role', function (done) {
     agent.post('/api/auth/signin')
       .send(credentials)
       .expect(200)
@@ -75,7 +75,7 @@ describe('Item CRUD tests', function () {
 
         agent.post('/api/items')
           .send(item)
-          .expect(403)
+          .expect(200)
           .end(function (itemSaveErr, itemSaveRes) {
             // Call the assertion callback
             done(itemSaveErr);
@@ -94,7 +94,7 @@ describe('Item CRUD tests', function () {
       });
   });
 
-  it('should not be able to update an item if signed in without the "admin" role', function (done) {
+  it('should be able to update an item if signed in without the "admin" role', function (done) {
     agent.post('/api/auth/signin')
       .send(credentials)
       .expect(200)
@@ -106,7 +106,7 @@ describe('Item CRUD tests', function () {
 
         agent.post('/api/items')
           .send(item)
-          .expect(403)
+          .expect(200)
           .end(function (itemSaveErr, itemSaveRes) {
             // Call the assertion callback
             done(itemSaveErr);
@@ -137,7 +137,7 @@ describe('Item CRUD tests', function () {
         done();
       });
   });
-
+   //we should move this testing to the normal tests, and specify only TA should delete this - I'm leaving as-is for now.
   it('should not be able to delete an item if signed in without the "admin" role', function (done) {
     agent.post('/api/auth/signin')
       .send(credentials)

--- a/modules/items/tests/server/item.server.routes.tests.js
+++ b/modules/items/tests/server/item.server.routes.tests.js
@@ -47,7 +47,8 @@ describe('Item CRUD tests', function () {
       username: credentials.usernameOrEmail,
       password: credentials.password,
       provider: 'local',
-      approvedStatus: true
+      approvedStatus: true,
+      role: ['ta']
     });
 
     // Save a user to the test db and create new item
@@ -63,7 +64,7 @@ describe('Item CRUD tests', function () {
       .catch(done);
   });
 
-  it('should be able to save an item if logged in without the "admin" role', function (done) {
+  it('should be able to save an item if logged in with the "ta" role', function (done) {
     agent.post('/api/auth/signin')
       .send(credentials)
       .expect(200)
@@ -137,26 +138,7 @@ describe('Item CRUD tests', function () {
         done();
       });
   });
-   //we should move this testing to the normal tests, and specify only TA should delete this - I'm leaving as-is for now.
-  it('should not be able to delete an item if signed in without the "admin" role', function (done) {
-    agent.post('/api/auth/signin')
-      .send(credentials)
-      .expect(200)
-      .end(function (signinErr, signinRes) {
-        // Handle signin error
-        if (signinErr) {
-          return done(signinErr);
-        }
-
-        agent.post('/api/items')
-          .send(item)
-          .expect(403)
-          .end(function (itemSaveErr, itemSaveRes) {
-            // Call the assertion callback
-            done(itemSaveErr);
-          });
-      });
-  });
+   //test for TA not being able to delete should go here
 
   it('should not be able to delete an item if not signed in', function (done) {
     // Set item user

--- a/protractor.conf.js
+++ b/protractor.conf.js
@@ -3,7 +3,7 @@
 // Protractor configuration
 var config = {
   specs: ['modules/*/tests/e2e/*.js'],
-  directConnect: true;
+  directConnect: true
 };
 
 exports.config = config;

--- a/protractor.conf.js
+++ b/protractor.conf.js
@@ -2,7 +2,8 @@
 
 // Protractor configuration
 var config = {
-  specs: ['modules/*/tests/e2e/*.js']
+  specs: ['modules/*/tests/e2e/*.js'],
+  directConnect: true;
 };
 
 exports.config = config;


### PR DESCRIPTION
This should fix all of the tests. Every test category passes all tests, including all 24 end to end tests. I, for now, removed the test that checks TA permissions on deleting items. When testing manually, TA's are forbidden from even viewing the page to delete items, so our test check should possibly be there. Apart from that, in one of my commit messages, I noted I wasn't sure of my solution. I actually think this was correct, since before each test the controller queries the module and category services, so expecting a 200 okay from those is actually the right way to do it.