### PR TITLE
Add user tests, applicant controller tests

### DIFF
--- a/config/env/test.js
+++ b/config/env/test.js
@@ -56,11 +56,12 @@ module.exports = {
       docs: [{
         overwrite: true,
         data: {
-          username: 'seedadmin',
+          username: 'seedadmintest',
           email: 'admin@localhost.com',
           firstName: 'Admin',
           lastName: 'Local',
-          roles: ['admin']
+          roles: ['admin'],
+          approvedStatus: true
         }
       }, {
         overwrite: true,

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -471,7 +471,7 @@ gulp.task('test:client', function (done) {
 });
 
 gulp.task('test:e2e', function (done) {
-  runSequence('env:test', 'lint', 'dropdb', 'nodemon', 'protractor', done);
+  runSequence('env:test', 'lint', 'dropdb', 'mongo-seed', 'nodemon', 'protractor', done);
 });
 
 gulp.task('test:coverage', function (done) {

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -454,7 +454,7 @@ gulp.task('build', function (done) {
 
 // Run the project tests
 gulp.task('test', function (done) {
-  runSequence('env:test', 'test:server', 'karma', 'nodemon', 'protractor', done);
+  runSequence('env:test', 'test:server', 'karma', 'dropdb', 'mongo-seed', 'nodemon', 'protractor', done);
 });
 
 gulp.task('test:server', function (done) {

--- a/modules/items/server/models/item.server.model.js
+++ b/modules/items/server/models/item.server.model.js
@@ -51,7 +51,7 @@ var ItemSchema = new Schema({
   modules: {
     type: Schema.ObjectId,
     ref: 'Module'
-  }
+  },
 });
 
 ItemSchema.statics.seed = seed;

--- a/modules/items/server/models/item.server.model.js
+++ b/modules/items/server/models/item.server.model.js
@@ -51,7 +51,7 @@ var ItemSchema = new Schema({
   modules: {
     type: Schema.ObjectId,
     ref: 'Module'
-  },
+  }
 });
 
 ItemSchema.statics.seed = seed;

--- a/modules/users/client/controllers/admin/view-applicants.client.controller.js
+++ b/modules/users/client/controllers/admin/view-applicants.client.controller.js
@@ -20,6 +20,7 @@
       if ($window.confirm('Are you sure you want to delete this user?')) {
         if (user) {
           ApplicantsService.remove(user);
+          vm.unapprovedUsers.splice(vm.unapprovedUsers.indexOf(user), 1);
           Notification.success('User deleted successfully!');
         }
       }
@@ -30,6 +31,7 @@
           var newUser = user;
           user.approvedStatus = true;
           ApplicantsService.changeToAccepted(newUser);
+          vm.unapprovedUsers.splice(vm.unapprovedUsers.indexOf(user), 1);
           Notification.success('User approved successfully!');
       }
     };

--- a/modules/users/client/controllers/admin/view-applicants.client.controller.js
+++ b/modules/users/client/controllers/admin/view-applicants.client.controller.js
@@ -19,7 +19,6 @@
     vm.removeApplicant = function (user) {
       if ($window.confirm('Are you sure you want to delete this user?')) {
         if (user) {
-          vm.unapprovedUsers.splice(vm.unapprovedUsers.indexOf(user), 1);
           ApplicantsService.remove(user);
           Notification.success('User deleted successfully!');
         }
@@ -31,7 +30,6 @@
           var newUser = user;
           user.approvedStatus = true;
           ApplicantsService.changeToAccepted(newUser);
-          vm.unapprovedUsers.splice(vm.unapprovedUsers.indexOf(user), 1);
           Notification.success('User approved successfully!');
       }
     };

--- a/modules/users/server/models/user.server.model.js
+++ b/modules/users/server/models/user.server.model.js
@@ -304,7 +304,13 @@ function seed(doc, options) {
 
             user.provider = 'local';
             user.displayName = user.firstName + ' ' + user.lastName;
-            user.password = passphrase;
+            if (user.username == 'seedadmintest')
+            {
+              user.password = 'P@$$w0rd!!';
+            }
+            else{
+              user.password = passphrase;
+            }
 
             user.save(function (err) {
               if (err) {

--- a/modules/users/tests/client/admin.view.applicants.controller.tests.js
+++ b/modules/users/tests/client/admin.view.applicants.controller.tests.js
@@ -53,7 +53,7 @@
       // create mock item
       mockUser = new ApplicantsService({
         roles: ['ta'],
-        approvedStatus: true
+        approvedStatus: false
       });
 
       // Mock logged in user
@@ -91,6 +91,43 @@
         expect($scope.vm.unapprovedUsers[1]).toEqual(mockUser);
 
       }));
+    });
+    describe('vm.approveUser() as update', function () {
+      var sampleUserPostData;
+      var mockUserList;
+
+      beforeEach(function () {
+        // Create a sample item object
+        sampleUserPostData = new ApplicantsService({
+          roles: ['ta'],
+          approvedStatus: false
+        });
+        mockUserList = [mockUser, mockUser];
+
+      });
+
+      it('should send a POST request with the form input values and then locate to new object URL', inject(function (ItemsService) {
+        //expect the initial get request
+        $httpBackend.expectGET('/api/unapproved').respond(mockUserList);
+        // Set POST response
+        $httpBackend.expectPOST('/api/unapproved', sampleUserPostData).respond(mockUser);
+
+        // Run controller functionality
+        $scope.vm.approveUser(sampleUserPostData);
+        $httpBackend.flush();
+      }));
+
+      it('should call Notification.error if error', function () {
+        var errorMessage = 'this is an error message';
+        $httpBackend.expectPOST('/api/items', sampleItemPostData).respond(400, {
+          message: errorMessage
+        });
+
+        $scope.vm.save(true);
+        $httpBackend.flush();
+
+        expect(Notification.error).toHaveBeenCalledWith({ message: errorMessage, title: '<i class="glyphicon glyphicon-remove"></i> Item save error!' });
+      });
     });
   });
 }());

--- a/modules/users/tests/client/admin.view.applicants.controller.tests.js
+++ b/modules/users/tests/client/admin.view.applicants.controller.tests.js
@@ -145,9 +145,10 @@
 
       });
 
-      it('should send a Delete request with the form input values and then locate to new object URL', inject(function (ItemsService) {
+      it('should send a Delete request with the applicants values', inject(function (ItemsService) {
         //expect the initial get request
         // expect a delte from the user with the approved status of false and a ta role
+        spyOn(window, 'confirm').and.returnValue(true);
         $httpBackend.expectDELETE('/api/unapproved?approvedStatus=false&roles=ta').respond(204);
 
         // Run controller functionality

--- a/modules/users/tests/client/admin.view.applicants.controller.tests.js
+++ b/modules/users/tests/client/admin.view.applicants.controller.tests.js
@@ -9,7 +9,8 @@
       $state,
       Authentication,
       ApplicantsService,
-      mockUser;
+      mockUser,
+      newlyApproved;
 
     // The $resource service augments the response object with methods for updating and deleting the resource.
     // If we were to use the standard toEqual matcher, our tests would fail because the test values would not match
@@ -55,6 +56,10 @@
         roles: ['ta'],
         approvedStatus: false
       });
+      newlyApproved = new ApplicantsService({
+        roles: ['ta'],
+        approvedStatus: true
+      });
 
       // Mock logged in user
       Authentication.user = {
@@ -94,6 +99,7 @@
     });
     describe('vm.approveUser() as update', function () {
       var sampleUserPostData;
+      var newlyApproved;
       var mockUserList;
 
       beforeEach(function () {
@@ -103,17 +109,19 @@
           approvedStatus: false
         });
         mockUserList = [mockUser, mockUser];
+        //expect the get request before each of these
+        $httpBackend.expectGET('/api/unapproved').respond(mockUserList);
+        $httpBackend.flush()
 
       });
 
       it('should send a POST request with the form input values and then locate to new object URL', inject(function (ItemsService) {
         //expect the initial get request
-        $httpBackend.expectGET('/api/unapproved').respond(mockUserList);
         // Set POST response
-        $httpBackend.expectPOST('/api/unapproved', sampleUserPostData).respond(mockUser);
+        $httpBackend.expectPOST('/api/unapproved', newlyApproved).respond(mockUser);
 
         // Run controller functionality
-        $scope.vm.approveUser(sampleUserPostData);
+        $scope.vm.approveUser(mockUser);
         $httpBackend.flush();
       }));
 

--- a/modules/users/tests/client/admin.view.applicants.controller.tests.js
+++ b/modules/users/tests/client/admin.view.applicants.controller.tests.js
@@ -115,7 +115,7 @@
 
       });
 
-      it('should send a POST request with the form input values and then locate to new object URL', inject(function (ItemsService) {
+      it('should send a POST request and end up with the same user with an approved value of true', inject(function (ItemsService) {
         //expect the initial get request
         // Set POST response
         $httpBackend.expectPOST('/api/unapproved', newlyApproved).respond(mockUser);
@@ -125,17 +125,35 @@
         $httpBackend.flush();
       }));
 
-      it('should call Notification.error if error', function () {
-        var errorMessage = 'this is an error message';
-        $httpBackend.expectPOST('/api/items', sampleItemPostData).respond(400, {
-          message: errorMessage
+      
+    });
+    describe('vm.denyUser() as delete', function () {
+      var sampleUserPostData;
+      var newlyApproved;
+      var mockUserList;
+
+      beforeEach(function () {
+        // Create a sample item object
+        sampleUserPostData = new ApplicantsService({
+          roles: ['ta'],
+          approvedStatus: false
         });
+        mockUserList = [mockUser, mockUser];
+        //expect the get request before each of these
+        $httpBackend.expectGET('/api/unapproved').respond(mockUserList);
+        $httpBackend.flush()
 
-        $scope.vm.save(true);
-        $httpBackend.flush();
-
-        expect(Notification.error).toHaveBeenCalledWith({ message: errorMessage, title: '<i class="glyphicon glyphicon-remove"></i> Item save error!' });
       });
+
+      it('should send a Delete request with the form input values and then locate to new object URL', inject(function (ItemsService) {
+        //expect the initial get request
+        // expect a delte from the user with the approved status of false and a ta role
+        $httpBackend.expectDELETE('/api/unapproved?approvedStatus=false&roles=ta').respond(204);
+
+        // Run controller functionality
+        $scope.vm.removeApplicant(mockUser);
+        $httpBackend.flush();
+      }));
     });
   });
 }());

--- a/modules/users/tests/client/admin.view.applicants.controller.tests.js
+++ b/modules/users/tests/client/admin.view.applicants.controller.tests.js
@@ -1,15 +1,15 @@
 (function () {
   'use strict';
 
-  describe('Admin Items List Controller Tests', function () {
+  describe('HOOO BOY THIS IS WHERE THE ADMIN VIEW CONTROLLER TESTS GO MY FRIEND', function () {
     // Initialize global variables
-    var ItemsAdminListController,
+    var ViewApplicantsController,
       $scope,
       $httpBackend,
       $state,
       Authentication,
-      ItemsService,
-      mockItem;
+      ApplicantsService,
+      mockUser;
 
     // The $resource service augments the response object with methods for updating and deleting the resource.
     // If we were to use the standard toEqual matcher, our tests would fail because the test values would not match
@@ -36,7 +36,7 @@
     // The injector ignores leading and trailing underscores here (i.e. _$httpBackend_).
     // This allows us to inject a service but then attach it to a variable
     // with the same name as the service.
-    beforeEach(inject(function ($controller, $rootScope, _$state_, _$httpBackend_, _Authentication_, _ItemsService_) {
+    beforeEach(inject(function ($controller, $rootScope, _$state_, _$httpBackend_, _Authentication_, _ApplicantsService_) {
       // Set a new global scope
       $scope = $rootScope.$new();
 
@@ -44,30 +44,26 @@
       $httpBackend = _$httpBackend_;
       $state = _$state_;
       Authentication = _Authentication_;
-      ItemsService = _ItemsService_;
+      ApplicantsService = _ApplicantsService_;
 
       // Ignore parent template get on state transitions
-      $httpBackend.whenGET('/modules/items/client/views/list-items.client.view.html').respond(200, '');
+      $httpBackend.whenGET('/modules/users/client/views/admin/view-applicants.html').respond(200, '');
       $httpBackend.whenGET('/modules/core/client/views/home.client.view.html').respond(200, '');
-      $httpBackend.whenGET('/api/categories').respond(200, '');
-      $httpBackend.whenGET('/api/modules').respond(200, '');
-
 
       // create mock item
-      mockItem = new ItemsService({
-        _id: '525a8422f6d0f87f0e407a33',
-        title: 'An Item about MEAN',
-        content: 'MEAN rocks!'
+      mockUser = new ApplicantsService({
+        roles: ['ta'],
+        approvedStatus: true
       });
 
       // Mock logged in user
       Authentication.user = {
-        roles: ['ta'],
+        roles: ['admin'],
         approvedStatus: true
       };
 
       // Initialize the Items List controller.
-      ItemsAdminListController = $controller('ItemsAdminListController as vm', {
+      ViewApplicantsController = $controller('ViewApplicantsController as vm', {
         $scope: $scope
       });
 
@@ -76,23 +72,23 @@
     }));
 
     describe('Instantiate', function () {
-      var mockItemList;
+      var mockUserList;
 
       beforeEach(function () {
-        mockItemList = [mockItem, mockItem];
+        mockUserList = [mockUser, mockUser];
       });
 
-      it('should send a GET request and return all items', inject(function (ItemsService) {
+      it('should send a GET request and return all users', inject(function (ItemsService) {
         // Set POST response
-        $httpBackend.expectGET('/api/items').respond(mockItemList);
+        $httpBackend.expectGET('/api/unapproved').respond(mockUserList);
 
 
         $httpBackend.flush();
 
         // Test form inputs are reset
-        expect($scope.vm.items.length).toEqual(2);
-        expect($scope.vm.items[0]).toEqual(mockItem);
-        expect($scope.vm.items[1]).toEqual(mockItem);
+        expect($scope.vm.unapprovedUsers.length).toEqual(2);
+        expect($scope.vm.unapprovedUsers[0]).toEqual(mockUser);
+        expect($scope.vm.unapprovedUsers[1]).toEqual(mockUser);
 
       }));
     });

--- a/modules/users/tests/client/admin.view.applicants.controller.tests.js
+++ b/modules/users/tests/client/admin.view.applicants.controller.tests.js
@@ -1,0 +1,100 @@
+(function () {
+  'use strict';
+
+  describe('Admin Items List Controller Tests', function () {
+    // Initialize global variables
+    var ItemsAdminListController,
+      $scope,
+      $httpBackend,
+      $state,
+      Authentication,
+      ItemsService,
+      mockItem;
+
+    // The $resource service augments the response object with methods for updating and deleting the resource.
+    // If we were to use the standard toEqual matcher, our tests would fail because the test values would not match
+    // the responses exactly. To solve the problem, we define a new toEqualData Jasmine matcher.
+    // When the toEqualData matcher compares two objects, it takes only object properties into
+    // account and ignores methods.
+    beforeEach(function () {
+      jasmine.addMatchers({
+        toEqualData: function (util, customEqualityTesters) {
+          return {
+            compare: function (actual, expected) {
+              return {
+                pass: angular.equals(actual, expected)
+              };
+            }
+          };
+        }
+      });
+    });
+
+    // Then we can start by loading the main application module
+    beforeEach(module(ApplicationConfiguration.applicationModuleName));
+
+    // The injector ignores leading and trailing underscores here (i.e. _$httpBackend_).
+    // This allows us to inject a service but then attach it to a variable
+    // with the same name as the service.
+    beforeEach(inject(function ($controller, $rootScope, _$state_, _$httpBackend_, _Authentication_, _ItemsService_) {
+      // Set a new global scope
+      $scope = $rootScope.$new();
+
+      // Point global variables to injected services
+      $httpBackend = _$httpBackend_;
+      $state = _$state_;
+      Authentication = _Authentication_;
+      ItemsService = _ItemsService_;
+
+      // Ignore parent template get on state transitions
+      $httpBackend.whenGET('/modules/items/client/views/list-items.client.view.html').respond(200, '');
+      $httpBackend.whenGET('/modules/core/client/views/home.client.view.html').respond(200, '');
+      $httpBackend.whenGET('/api/categories').respond(200, '');
+      $httpBackend.whenGET('/api/modules').respond(200, '');
+
+
+      // create mock item
+      mockItem = new ItemsService({
+        _id: '525a8422f6d0f87f0e407a33',
+        title: 'An Item about MEAN',
+        content: 'MEAN rocks!'
+      });
+
+      // Mock logged in user
+      Authentication.user = {
+        roles: ['ta'],
+        approvedStatus: true
+      };
+
+      // Initialize the Items List controller.
+      ItemsAdminListController = $controller('ItemsAdminListController as vm', {
+        $scope: $scope
+      });
+
+      // Spy on state go
+      spyOn($state, 'go');
+    }));
+
+    describe('Instantiate', function () {
+      var mockItemList;
+
+      beforeEach(function () {
+        mockItemList = [mockItem, mockItem];
+      });
+
+      it('should send a GET request and return all items', inject(function (ItemsService) {
+        // Set POST response
+        $httpBackend.expectGET('/api/items').respond(mockItemList);
+
+
+        $httpBackend.flush();
+
+        // Test form inputs are reset
+        expect($scope.vm.items.length).toEqual(2);
+        expect($scope.vm.items[0]).toEqual(mockItem);
+        expect($scope.vm.items[1]).toEqual(mockItem);
+
+      }));
+    });
+  });
+}());

--- a/modules/users/tests/e2e/users.e2e.tests.js
+++ b/modules/users/tests/e2e/users.e2e.tests.js
@@ -6,7 +6,8 @@ describe('Users E2E Tests:', function () {
     lastName: 'user',
     email: 'test.user@meanjs.com',
     username: 'testUser',
-    password: 'P@$$w0rd!!'
+    password: 'P@$$w0rd!!',
+    role: 'TA'
   };
 
   var user2 = {
@@ -14,7 +15,8 @@ describe('Users E2E Tests:', function () {
     lastName: 'user2',
     email: 'test.user2@meanjs.com',
     username: 'testUser2',
-    password: 'P@$$w0rd!!'
+    password: 'P@$$w0rd!!',
+    role: 'TA'
   };
   var admin = {
     username: 'seedadmintest',
@@ -53,7 +55,7 @@ describe('Users E2E Tests:', function () {
       // Enter Username
       element(by.model('vm.credentials.username')).sendKeys(user1.username);
       // Enter Password
-      element(by.model('vm.credentials.password')).sendKeys(user1.password);
+      element(by.model('vm.credentials.roles')).sendKeys(user1.role);
       // Click Submit button
       element(by.css('button[type=submit]')).click();
       // First Name Error
@@ -68,7 +70,7 @@ describe('Users E2E Tests:', function () {
       // Enter Username
       element(by.model('vm.credentials.username')).sendKeys(user1.username);
       // Enter Password
-      element(by.model('vm.credentials.password')).sendKeys(user1.password);
+      element(by.model('vm.credentials.roles')).sendKeys(user1.role);
       // Click Submit button
       element(by.css('button[type=submit]')).click();
       // Last Name Error

--- a/modules/users/tests/e2e/users.e2e.tests.js
+++ b/modules/users/tests/e2e/users.e2e.tests.js
@@ -16,6 +16,10 @@ describe('Users E2E Tests:', function () {
     username: 'testUser2',
     password: 'P@$$w0rd!!'
   };
+  var admin = {
+    username: 'seedadmintest',
+    password: 'P@$$w0rd!!'
+  };
 
   var signout = function () {
     // Make sure user is signed out first
@@ -24,8 +28,57 @@ describe('Users E2E Tests:', function () {
     browser.driver.manage().deleteAllCookies();
   };
 
+  var signin = function() {
+    signout();
+    browser.get('http://localhost:3001/signin');
+      // Enter UserName
+      element(by.model('vm.credentials.usernameOrEmail')).sendKeys(admin.username);
+      // Enter Password
+      element(by.model('vm.credentials.password')).sendKeys(admin.password);
+      // Click Submit button
+      element(by.css('button[type="submit"]')).click();
+      expect(browser.getCurrentUrl()).toEqual('http://localhost:3001/');
+  };
+  describe('AddUsers Tests', function () {
+
+    it('Should report missing first name', function () {
+      // Sign in
+      signin();
+      browser.get('http://localhost:3001/admin/add');
+      // Enter Last Name
+      element(by.model('vm.credentials.lastName')).sendKeys(user1.lastName);
+      // Enter Email
+      element(by.model('vm.credentials.email')).sendKeys(user1.email);
+      //Enter Additional Elements
+      // Enter Username
+      element(by.model('vm.credentials.username')).sendKeys(user1.username);
+      // Enter Password
+      element(by.model('vm.credentials.password')).sendKeys(user1.password);
+      // Click Submit button
+      element(by.css('button[type=submit]')).click();
+      // First Name Error
+      expect(element.all(by.css('.error-text')).get(0).getText()).toBe('First name is required.');
+    });
+    it('Should report missing last name', function () {
+      browser.get('http://localhost:3001/admin/add');
+      // Enter First Name
+      element(by.model('vm.credentials.firstName')).sendKeys(user1.firstName);
+      // Enter Email
+      element(by.model('vm.credentials.email')).sendKeys(user1.email);
+      // Enter Username
+      element(by.model('vm.credentials.username')).sendKeys(user1.username);
+      // Enter Password
+      element(by.model('vm.credentials.password')).sendKeys(user1.password);
+      // Click Submit button
+      element(by.css('button[type=submit]')).click();
+      // Last Name Error
+      expect(element.all(by.css('.error-text')).get(0).getText()).toBe('Last name is required.');
+    });
+
+  });
   describe('Signup Validation', function () {
     it('Should report missing first name', function () {
+      signout();
       browser.get('http://localhost:3001/signup');
       // Enter Last Name
       element(by.model('vm.credentials.lastName')).sendKeys(user1.lastName);

--- a/modules/users/tests/e2e/users.e2e.tests.js
+++ b/modules/users/tests/e2e/users.e2e.tests.js
@@ -57,6 +57,7 @@ describe('Users E2E Tests:', function () {
       element(by.css('button[type="submit"]')).click();
       expect(browser.getCurrentUrl()).toEqual('http://localhost:3001/');
   };
+
   describe('AddUsers Tests', function () {
 
     it('Should report missing first name', function () {
@@ -245,7 +246,7 @@ describe('Users E2E Tests:', function () {
       expect(element.all(by.css('.error-text')).get(0).getText()).toBe('Please enter a valid username: 3+ characters long, non restricted word, characters "_-.", no consecutive dots, does not begin or end with dots, letters a-z and numbers 0-9.');
     });
 
-    it('Should admin/add username with . - "log.in2"', function () {
+    it('Should admin/add username with . - "2log.in2"', function () {
       browser.get('http://localhost:3001/admin/add');
       // Enter First Name
       element(by.model('vm.credentials.firstName')).sendKeys(user4.firstName);
@@ -254,7 +255,7 @@ describe('Users E2E Tests:', function () {
       // Enter Email
       element(by.model('vm.credentials.email')).sendKeys('someemail@meanjs.com');
       // Enter Username
-      element(by.model('vm.credentials.username')).sendKeys('log.in2');
+      element(by.model('vm.credentials.username')).sendKeys('2log.in2');
       // Enter roles
       element(by.model('vm.credentials.roles')).sendKeys(user4.roles);
       //Enter Additional Elements
@@ -536,7 +537,7 @@ describe('Users E2E Tests:', function () {
       // Enter Last Name
       element(by.model('vm.credentials.lastName')).sendKeys(user2.lastName);
       // Enter Email
-      element(by.model('vm.credentials.email')).sendKeys('someemail@meanjs.com');
+      element(by.model('vm.credentials.email')).sendKeys('someemail2@meanjs.com');
       // Enter Username
       element(by.model('vm.credentials.username')).sendKeys('log.in');
       // Enter Password
@@ -742,7 +743,6 @@ describe('Users E2E Tests:', function () {
     });
 
   });
-
   describe('Signin Validation', function () {
 
     it('Should report missing credentials', function () {

--- a/modules/users/tests/e2e/users.e2e.tests.js
+++ b/modules/users/tests/e2e/users.e2e.tests.js
@@ -7,7 +7,7 @@ describe('Users E2E Tests:', function () {
     email: 'test.user@meanjs.com',
     username: 'testUser',
     password: 'P@$$w0rd!!',
-    role: 'TA'
+    roles: 'TA'
   };
 
   var user2 = {
@@ -16,11 +16,27 @@ describe('Users E2E Tests:', function () {
     email: 'test.user2@meanjs.com',
     username: 'testUser2',
     password: 'P@$$w0rd!!',
-    role: 'TA'
+    roles: 'TA'
   };
   var admin = {
     username: 'seedadmintest',
     password: 'P@$$w0rd!!'
+  };
+  var user3 = {
+    firstName: 'test',
+    lastName: 'user',
+    email: 'test.user3@meanjs.com',
+    username: 'testUser3',
+    password: 'P@$$w0rd!!',
+    roles: 'TA'
+  };
+  var user4 = {
+    firstName: 'test',
+    lastName: 'user4',
+    email: 'test.user4@meanjs.com',
+    username: 'testUser4',
+    password: 'P@$$w0rd!!',
+    roles: 'TA'
   };
 
   var signout = function () {
@@ -48,14 +64,14 @@ describe('Users E2E Tests:', function () {
       signin();
       browser.get('http://localhost:3001/admin/add');
       // Enter Last Name
-      element(by.model('vm.credentials.lastName')).sendKeys(user1.lastName);
+      element(by.model('vm.credentials.lastName')).sendKeys(user3.lastName);
       // Enter Email
-      element(by.model('vm.credentials.email')).sendKeys(user1.email);
+      element(by.model('vm.credentials.email')).sendKeys(user3.email);
       //Enter Additional Elements
       // Enter Username
-      element(by.model('vm.credentials.username')).sendKeys(user1.username);
+      element(by.model('vm.credentials.username')).sendKeys(user3.username);
       // Enter Password
-      element(by.model('vm.credentials.roles')).sendKeys(user1.role);
+      element(by.model('vm.credentials.roles')).sendKeys(user3.roles);
       // Click Submit button
       element(by.css('button[type=submit]')).click();
       // First Name Error
@@ -64,17 +80,264 @@ describe('Users E2E Tests:', function () {
     it('Should report missing last name', function () {
       browser.get('http://localhost:3001/admin/add');
       // Enter First Name
-      element(by.model('vm.credentials.firstName')).sendKeys(user1.firstName);
+      element(by.model('vm.credentials.firstName')).sendKeys(user3.firstName);
       // Enter Email
-      element(by.model('vm.credentials.email')).sendKeys(user1.email);
+      element(by.model('vm.credentials.email')).sendKeys(user3.email);
       // Enter Username
-      element(by.model('vm.credentials.username')).sendKeys(user1.username);
+      element(by.model('vm.credentials.username')).sendKeys(user3.username);
       // Enter Password
-      element(by.model('vm.credentials.roles')).sendKeys(user1.role);
+      element(by.model('vm.credentials.roles')).sendKeys(user3.roles);
       // Click Submit button
       element(by.css('button[type=submit]')).click();
       // Last Name Error
       expect(element.all(by.css('.error-text')).get(0).getText()).toBe('Last name is required.');
+    });
+    it('Should report missing email address', function () {
+      browser.get('http://localhost:3001/admin/add');
+      // Enter First Name
+      element(by.model('vm.credentials.firstName')).sendKeys(user3.firstName);
+      // Enter Last Name
+      element(by.model('vm.credentials.lastName')).sendKeys(user3.lastName);
+      // Enter Username
+      element(by.model('vm.credentials.username')).sendKeys(user3.username);
+      // Enter roles
+      element(by.model('vm.credentials.roles')).sendKeys(user3.roles);
+      // Click Submit button
+      element(by.css('button[type=submit]')).click();
+      // Email address error
+      expect(element.all(by.css('.error-text')).get(0).getText()).toBe('Email address is required.');
+    });
+
+    it('Should report invalid email address - "123"', function () {
+      browser.get('http://localhost:3001/admin/add');
+      // Enter First Name
+      element(by.model('vm.credentials.firstName')).sendKeys(user3.firstName);
+      // Enter Last Name
+      element(by.model('vm.credentials.lastName')).sendKeys(user3.lastName);
+      // Enter Email
+      element(by.model('vm.credentials.email')).sendKeys('123');
+      // Enter Username
+      element(by.model('vm.credentials.username')).sendKeys(user3.username);
+      // Enter roles
+      element(by.model('vm.credentials.roles')).sendKeys(user3.roles);
+      //Enter Additional Elements
+      // Click Submit button
+      element(by.css('button[type=submit]')).click();
+      // Email address error
+      expect(element.all(by.css('.error-text')).get(0).getText()).toBe('Email address is invalid.');
+    });
+
+    /**
+     * Note: 123@123 is a valid email adress according to HTML5.
+     * However, 123@123@123 is an invalid email address.
+     */
+    it('Should report invalid email address - "123@123@123"', function () {
+      browser.get('http://localhost:3001/admin/add');
+      // Enter First Name
+      element(by.model('vm.credentials.firstName')).sendKeys(user3.firstName);
+      // Enter Last Name
+      element(by.model('vm.credentials.lastName')).sendKeys(user3.lastName);
+      // Enter Email
+      element(by.model('vm.credentials.email')).sendKeys('123@123@123');
+      // Enter Username
+      element(by.model('vm.credentials.username')).sendKeys(user3.username);
+      // Enter roles
+      element(by.model('vm.credentials.roles')).sendKeys(user3.roles);
+      //Enter Additional Elements
+      // Click Submit button
+      element(by.css('button[type=submit]')).click();
+      // Email address error
+      expect(element.all(by.css('.error-text')).get(0).getText()).toBe('Email address is invalid.');
+    });
+
+    it('Should report invalid username - ".login"', function () {
+      browser.get('http://localhost:3001/admin/add');
+      // Enter First Name
+      element(by.model('vm.credentials.firstName')).sendKeys(user3.firstName);
+      // Enter Last Name
+      element(by.model('vm.credentials.lastName')).sendKeys(user3.lastName);
+      // Enter Email
+      element(by.model('vm.credentials.email')).sendKeys(user3.email);
+      // Enter Username
+      element(by.model('vm.credentials.username')).sendKeys('.login');
+      //Enter Additional Elements
+      // Enter roles
+      element(by.model('vm.credentials.roles')).sendKeys(user3.roles);
+      // Click Submit button
+      element(by.css('button[type=submit]')).click();
+      // Email address error
+      expect(element.all(by.css('.error-text')).get(0).getText()).toBe('Please enter a valid username: 3+ characters long, non restricted word, characters "_-.", no consecutive dots, does not begin or end with dots, letters a-z and numbers 0-9.');
+    });
+
+    it('Should report invalid username - "login."', function () {
+      browser.get('http://localhost:3001/admin/add');
+      // Enter First Name
+      element(by.model('vm.credentials.firstName')).sendKeys(user3.firstName);
+      // Enter Last Name
+      element(by.model('vm.credentials.lastName')).sendKeys(user3.lastName);
+      // Enter Email
+      element(by.model('vm.credentials.email')).sendKeys(user3.email);
+      // Enter Username
+      element(by.model('vm.credentials.username')).sendKeys('login.');
+      // Enter roles
+      element(by.model('vm.credentials.roles')).sendKeys(user3.roles);
+      //Enter Additional Elements
+      // Click Submit button
+      element(by.css('button[type=submit]')).click();
+      // Email address error
+      expect(element.all(by.css('.error-text')).get(0).getText()).toBe('Please enter a valid username: 3+ characters long, non restricted word, characters "_-.", no consecutive dots, does not begin or end with dots, letters a-z and numbers 0-9.');
+    });
+
+    it('Should report invalid username - "log..in"', function () {
+      browser.get('http://localhost:3001/admin/add');
+      // Enter First Name
+      element(by.model('vm.credentials.firstName')).sendKeys(user3.firstName);
+      // Enter Last Name
+      element(by.model('vm.credentials.lastName')).sendKeys(user3.lastName);
+      // Enter Email
+      element(by.model('vm.credentials.email')).sendKeys(user3.email);
+      // Enter Username
+      element(by.model('vm.credentials.username')).sendKeys('log..in');
+      // Enter roles
+      element(by.model('vm.credentials.roles')).sendKeys(user3.roles);
+      //Enter Additional Elements
+      // Click Submit button
+      element(by.css('button[type=submit]')).click();
+      // Email address error
+      expect(element.all(by.css('.error-text')).get(0).getText()).toBe('Please enter a valid username: 3+ characters long, non restricted word, characters "_-.", no consecutive dots, does not begin or end with dots, letters a-z and numbers 0-9.');
+    });
+
+    it('Should report invalid username - "lo"', function () {
+      browser.get('http://localhost:3001/admin/add');
+      // Enter First Name
+      element(by.model('vm.credentials.firstName')).sendKeys(user3.firstName);
+      // Enter Last Name
+      element(by.model('vm.credentials.lastName')).sendKeys(user3.lastName);
+      // Enter Email
+      element(by.model('vm.credentials.email')).sendKeys(user3.email);
+      // Enter Username
+      element(by.model('vm.credentials.username')).sendKeys('lo');
+      // Enter roles
+      element(by.model('vm.credentials.roles')).sendKeys(user3.roles);
+      //Enter Additional Elements
+      // Click Submit button
+      element(by.css('button[type=submit]')).click();
+      // Email address error
+      expect(element.all(by.css('.error-text')).get(0).getText()).toBe('Please enter a valid username: 3+ characters long, non restricted word, characters "_-.", no consecutive dots, does not begin or end with dots, letters a-z and numbers 0-9.');
+    });
+
+    it('Should report invalid username - "log$in"', function () {
+      browser.get('http://localhost:3001/admin/add');
+      // Enter First Name
+      element(by.model('vm.credentials.firstName')).sendKeys(user3.firstName);
+      // Enter Last Name
+      element(by.model('vm.credentials.lastName')).sendKeys(user3.lastName);
+      // Enter Email
+      element(by.model('vm.credentials.email')).sendKeys(user3.email);
+      // Enter Username
+      element(by.model('vm.credentials.username')).sendKeys('log$in');
+      // Enter roles
+      element(by.model('vm.credentials.roles')).sendKeys(user3.roles);
+      //Enter Additional Elements
+      // Click Submit button
+      element(by.css('button[type=submit]')).click();
+      // Email address error
+      expect(element.all(by.css('.error-text')).get(0).getText()).toBe('Please enter a valid username: 3+ characters long, non restricted word, characters "_-.", no consecutive dots, does not begin or end with dots, letters a-z and numbers 0-9.');
+    });
+
+    it('Should admin/add username with . - "log.in2"', function () {
+      browser.get('http://localhost:3001/admin/add');
+      // Enter First Name
+      element(by.model('vm.credentials.firstName')).sendKeys(user4.firstName);
+      // Enter Last Name
+      element(by.model('vm.credentials.lastName')).sendKeys(user4.lastName);
+      // Enter Email
+      element(by.model('vm.credentials.email')).sendKeys('someemail@meanjs.com');
+      // Enter Username
+      element(by.model('vm.credentials.username')).sendKeys('log.in2');
+      // Enter roles
+      element(by.model('vm.credentials.roles')).sendKeys(user4.roles);
+      //Enter Additional Elements
+      // Click Submit button
+      element(by.css('button[type=submit]')).click();
+      // Signup successful with username having .
+      expect(browser.getCurrentUrl()).toEqual('http://localhost:3001/');
+    });
+
+    it('Should report missing username', function () {
+      browser.get('http://localhost:3001/admin/add');
+      // Enter First Name
+      element(by.model('vm.credentials.firstName')).sendKeys(user3.firstName);
+      // Enter Last Name
+      element(by.model('vm.credentials.lastName')).sendKeys(user3.lastName);
+      // Enter Email
+      element(by.model('vm.credentials.email')).sendKeys(user3.email);
+      // Enter roles
+      element(by.model('vm.credentials.roles')).sendKeys(user3.roles);
+      //Enter Additional Elements
+      // Click Submit button
+      element(by.css('button[type=submit]')).click();
+      // Username Error
+      expect(element.all(by.css('.error-text')).get(0).getText()).toBe('Username is required.');
+    });
+
+
+    it('Should Successfully register new user', function () {
+      browser.get('http://localhost:3001/admin/add');
+      // Enter FirstName
+      element(by.model('vm.credentials.firstName')).sendKeys(user3.firstName);
+      // Enter LastName
+      element(by.model('vm.credentials.lastName')).sendKeys(user3.lastName);
+      // Enter Email
+      element(by.model('vm.credentials.email')).sendKeys(user3.email);
+      // Enter UserName
+      element(by.model('vm.credentials.username')).sendKeys(user3.username);
+      // Enter roles
+      element(by.model('vm.credentials.roles')).sendKeys(user3.roles);
+      //Enter Additional Elements
+      // Click Submit button
+      element(by.css('button[type="submit"]')).click();
+      expect(browser.getCurrentUrl()).toEqual('http://localhost:3001/');
+    });
+
+    it('Should report Email already exists', function () {
+      // Make sure user is signed out first
+      browser.get('http://localhost:3001/admin/add');
+      // Enter First Name
+      element(by.model('vm.credentials.firstName')).sendKeys(user4.firstName);
+      // Enter Last Name
+      element(by.model('vm.credentials.lastName')).sendKeys(user4.lastName);
+      // Enter Email
+      element(by.model('vm.credentials.email')).sendKeys(user3.email);
+      // Enter Username
+      element(by.model('vm.credentials.username')).sendKeys(user4.username);
+      // Enter Invalid roles
+      element(by.model('vm.credentials.roles')).sendKeys(user4.roles);
+      //Enter Additional Elements
+      // Click Submit button
+      element(by.css('button[type=submit]')).click();
+      // roles Error
+      expect(element.all(by.css('.message')).get(0).getText()).toBe('Email already exists');
+    });
+
+    it('Should report Username already exists', function () {
+      // Signup
+      browser.get('http://localhost:3001/admin/add');
+      // Enter First Name
+      element(by.model('vm.credentials.firstName')).sendKeys(user4.firstName);
+      // Enter Last Name
+      element(by.model('vm.credentials.lastName')).sendKeys(user4.lastName);
+      // Enter Email
+      element(by.model('vm.credentials.email')).sendKeys(user4.email);
+      // Enter Username
+      element(by.model('vm.credentials.username')).sendKeys(user3.username);
+      // Enter Invalid roles
+      element(by.model('vm.credentials.roles')).sendKeys(user4.roles);
+      //Enter Additional Elements
+      // Click Submit button
+      element(by.css('button[type=submit]')).click();
+      // roles Error
+      expect(element.all(by.css('.message')).get(0).getText()).toBe('Username already exists');
     });
 
   });


### PR DESCRIPTION
Added tests for the ApprovingApplicants controller. These tests cover Instantiate (get), Approve user as update, and  deny user as delete. I believe this covers all functionality for the approve applicants page, but I may need to add a test for approving all applicants.

Additionally, I wrote E2E tests for the admin/add view, where an admin manually adds a user to the system. This included altering the gulpfile to allow npm test and npm run test:e2e to properly execute. They now seed the database with an admin user, and are sure to clear the database before each use. 

Attached are screenshots (I hope, I have no idea if these uploaded correctly) of me running npm test before submission to verify all tests pass.
![screenshot 156](https://user-images.githubusercontent.com/9067633/33042403-bf87e28c-ce0f-11e7-96e8-9cdec9c479d0.png)
![screenshot 157](https://user-images.githubusercontent.com/9067633/33042404-bf9dfbbc-ce0f-11e7-8520-73cc4b3ae6eb.png)
![screenshot 158](https://user-images.githubusercontent.com/9067633/33042405-bfae1a56-ce0f-11e7-8a14-2db390e6cbae.png)
![screenshot 159](https://user-images.githubusercontent.com/9067633/33042406-c011560c-ce0f-11e7-915b-c438015d7ec6.png)



