### PR TITLE
Added route tests

### DIFF
--- a/modules/items/tests/server/admin.item.server.routes.tests.js
+++ b/modules/items/tests/server/admin.item.server.routes.tests.js
@@ -6,6 +6,8 @@ var should = require('should'),
   mongoose = require('mongoose'),
   User = mongoose.model('User'),
   Item = mongoose.model('Item'),
+  Category = mongoose.model('Category'),
+  Module = mongoose.model('Module'),
   express = require(path.resolve('./config/lib/express'));
 
 /**
@@ -15,7 +17,9 @@ var app,
   agent,
   credentials,
   user,
-  item;
+  item,
+  category,
+  module;
 
 /**
  * Item routes tests
@@ -57,6 +61,12 @@ describe('Item Admin CRUD tests', function () {
         item = {
           title: 'Item Title',
           content: 'Item Content'
+        }
+        category = {
+          title: 'Category Title'
+        }
+        module = {
+          title: 'Module Title'
         };
 
         done();
@@ -101,6 +111,49 @@ describe('Item Admin CRUD tests', function () {
                 // Set assertions
                 (items[0].user._id).should.equal(userId);
                 (items[0].title).should.match('Item Title');
+
+                // Call the assertion callback
+                done();
+              });
+          });
+      });
+  });
+  it('should be able to save a category if logged in', function (done) {
+    agent.post('/api/auth/signin')
+      .send(credentials)
+      .expect(200)
+      .end(function (signinErr, signinRes) {
+        // Handle signin error
+        if (signinErr) {
+          return done(signinErr);
+        }
+
+        // Get the userId
+        var userId = user.id;
+
+        // Save a new item
+        agent.post('/api/categories')
+          .send(category)
+          .expect(200)
+          .end(function (categorySaveErr, cateogrySaveRes) {
+            // Handle item save error
+            if (categorySaveErr) {
+              return done(categorySaveErr);
+            }
+
+            // Get a list of items
+            agent.get('/api/categories')
+              .end(function (categoriesGetErr, categoriesGetRes) {
+                // Handle item save error
+                if (categoriesGetErr) {
+                  return done(categoriesGetErr);
+                }
+
+                // Get items list
+                var categories = categoriesGetRes.body;
+
+                // Set assertions
+                (categories[0].title).should.match('Category Title');
 
                 // Call the assertion callback
                 done();

--- a/modules/items/tests/server/admin.item.server.routes.tests.js
+++ b/modules/items/tests/server/admin.item.server.routes.tests.js
@@ -135,7 +135,7 @@ describe('Item Admin CRUD tests', function () {
         agent.post('/api/categories')
           .send(category)
           .expect(200)
-          .end(function (categorySaveErr, cateogrySaveRes) {
+          .end(function (categorySaveErr, categorySaveRes) {
             // Handle item save error
             if (categorySaveErr) {
               return done(categorySaveErr);
@@ -154,6 +154,49 @@ describe('Item Admin CRUD tests', function () {
 
                 // Set assertions
                 (categories[0].title).should.match('Category Title');
+
+                // Call the assertion callback
+                done();
+              });
+          });
+      });
+  });
+  it('should be able to save a module if logged in', function (done) {
+    agent.post('/api/auth/signin')
+      .send(credentials)
+      .expect(200)
+      .end(function (signinErr, signinRes) {
+        // Handle signin error
+        if (signinErr) {
+          return done(signinErr);
+        }
+
+        // Get the userId
+        var userId = user.id;
+
+        // Save a new item
+        agent.post('/api/modules')
+          .send(module)
+          .expect(200)
+          .end(function (moduleSaveErr, moduleSaveRes) {
+            // Handle item save error
+            if (moduleSaveErr) {
+              return done(moduleSaveErr);
+            }
+
+            // Get a list of items
+            agent.get('/api/modules')
+              .end(function (modulesGetErr, modulesGetRes) {
+                // Handle item save error
+                if (modulesGetErr) {
+                  return done(modulesGetErr);
+                }
+
+                // Get items list
+                var modules = modulesGetRes.body;
+
+                // Set assertions
+                (modules[0].title).should.match('Module Title');
 
                 // Call the assertion callback
                 done();

--- a/modules/items/tests/server/item.server.model.tests.js
+++ b/modules/items/tests/server/item.server.model.tests.js
@@ -6,18 +6,22 @@
 var should = require('should'),
   mongoose = require('mongoose'),
   User = mongoose.model('User'),
-  Item = mongoose.model('Item');
+  Item = mongoose.model('Item'),
+  Category = mongoose.model('Category'),
+  Module = mongoose.model('Module');
 
 /**
  * Globals
  */
 var user,
-  item;
+  item,
+  category,
+  module;
 
 /**
  * Unit tests
  */
-describe('Item Model Unit Tests:', function () {
+describe('Item/Category/Module Model Unit Tests:', function () {
 
   beforeEach(function (done) {
     user = new User({
@@ -36,15 +40,21 @@ describe('Item Model Unit Tests:', function () {
           title: 'Item Title',
           content: 'Item Content',
           user: user
+        })
+        category = new Category({
+        title: 'Category Title'
+        })
+        module = new Module({
+        title: 'Module Title'
         });
-
         done();
       })
       .catch(done);
+
   });
 
   describe('Method Save', function () {
-    it('should be able to save without problems', function (done) {
+    it('should be able to save item without problems', function (done) {
       this.timeout(10000);
       item.save(function (err) {
         should.not.exist(err);
@@ -52,7 +62,7 @@ describe('Item Model Unit Tests:', function () {
       });
     });
 
-    it('should be able to show an error when try to save without title', function (done) {
+    it('should be able to show an error when try to save item without title', function (done) {
       item.title = '';
 
       item.save(function (err) {
@@ -60,10 +70,43 @@ describe('Item Model Unit Tests:', function () {
         return done();
       });
     });
+    it('should be able to save category without problems', function (done) {
+      this.timeout(10000);
+      category.save(function (err) {
+        should.not.exist(err);
+        return done();
+      });
+    });
+    it('should be able to show an error when try to save category without title', function (done) {
+      category.title = '';
+
+      category.save(function (err) {
+        should.exist(err);
+        return done();
+      });
+    });
+  it('should be able to save module without problems', function (done) {
+      this.timeout(10000);
+      item.save(function (err) {
+        should.not.exist(err);
+        return done();
+      });
+    });
+  it('should be able to show an error when try to save module without title', function (done) {
+      module.title = '';
+
+      module.save(function (err) {
+        should.exist(err);
+        return done();
+      });
+    });
   });
+  
 
   afterEach(function (done) {
     Item.remove().exec()
+      .then(Module.remove().exec())
+      .then(Category.remove().exec())
       .then(User.remove().exec())
       .then(done())
       .catch(done);

--- a/modules/items/tests/server/item.server.routes.tests.js
+++ b/modules/items/tests/server/item.server.routes.tests.js
@@ -190,6 +190,50 @@ describe('Item CRUD tests', function () {
 
     });
   });
+  it('should not be able to delete an category if not signed in', function (done) {
+    // Set item user
+    category.title = 'user';
+
+    // Create new item model instance
+    var catObj = new Category(category);
+
+    // Save the item
+    catObj.save(function () {
+      // Try deleting item
+      agent.delete('/api/categories')
+        .expect(403)
+        .end(function (itemDeleteErr, itemDeleteRes) {
+          // Set message assertion
+          (itemDeleteRes.body.message).should.match('User is not yet approved for database changes (check attribute approvedStatus)');
+
+          // Handle item error error
+          done(itemDeleteErr);
+        });
+
+    });
+  });
+  it('should not be able to delete an module if not signed in', function (done) {
+    // Set item user
+    module.title = 'user';
+
+    // Create new item model instance
+    var modObj = new Module(module);
+
+    // Save the item
+    modObj.save(function () {
+      // Try deleting item
+      agent.delete('/api/modules')
+        .expect(403)
+        .end(function (itemDeleteErr, itemDeleteRes) {
+          // Set message assertion
+          (itemDeleteRes.body.message).should.match('User is not yet approved for database changes (check attribute approvedStatus)');
+
+          // Handle item error error
+          done(itemDeleteErr);
+        });
+
+    });
+  });
 
   it('should be able to get a single item that has an orphaned user reference', function (done) {
     // Create orphan user creds

--- a/modules/items/tests/server/item.server.routes.tests.js
+++ b/modules/items/tests/server/item.server.routes.tests.js
@@ -104,6 +104,24 @@ describe('Item CRUD tests', function () {
         done(itemSaveErr);
       });
   });
+  it('should not be able to save a category if not logged in', function (done) {
+    agent.post('/api/categories')
+      .send(category)
+      .expect(403)
+      .end(function (categorySaveErr, categorySaveRes) {
+        // Call the assertion callback
+        done(categorySaveErr);
+      });
+  });
+  it('should not be able to save a module if not logged in', function (done) {
+    agent.post('/api/modules')
+      .send(module)
+      .expect(403)
+      .end(function (moduleSaveErr, moduleSaveRes) {
+        // Call the assertion callback
+        done(moduleSaveErr);
+      });
+  });
 
   it('should be able to update an item if signed in without the "admin" role', function (done) {
     agent.post('/api/auth/signin')

--- a/modules/items/tests/server/item.server.routes.tests.js
+++ b/modules/items/tests/server/item.server.routes.tests.js
@@ -6,6 +6,8 @@ var should = require('should'),
   mongoose = require('mongoose'),
   User = mongoose.model('User'),
   Item = mongoose.model('Item'),
+  Category = mongoose.model('Category'),
+  Module = mongoose.model('Module'),
   express = require(path.resolve('./config/lib/express'));
 
 /**
@@ -15,7 +17,9 @@ var app,
   agent,
   credentials,
   user,
-  item;
+  item,
+  category,
+  module;
 
 /**
  * Item routes tests
@@ -57,7 +61,13 @@ describe('Item CRUD tests', function () {
         item = {
           title: 'Item Title',
           content: 'Item Content'
-        };
+        }
+        category = {
+          title: 'Category Title'
+        }
+        module = {
+          title: 'Module Title'
+        }
 
         done();
       })


### PR DESCRIPTION
Added some tests for CRUD operations for categories and modules. Rather than give them their own folder, I opted to lump them in with the module tests. They are distinguished by their 'describe' headers, so they should still be easy to find in the test log. I also added some basic API route tests for categories and modules, but I only figured out create. Due to the way we set up the API for modules and categories, I can't figure out how to get the delete route test to work, since my only frame of reference is the Items delete test, which uses a /api/items/id route, while we don't have an ID route for Cats and Mods, and I don't really want to mess with that at this point.
Tests descriptors added:
1. should be able to save a module if logged in
2. 'should be able to save a category if logged in'
3. should not be able to save a category if not logged in
4. should not be able to save a module if not logged in
5. should not be able to delete a category if not signed in
6. should not be able to delete a module if not signed in
7. should be able to save category without problems
8. should be able to show an error when try to save category without title
9. should be able to save module without problems
10. should be able to show an error when try to save module without title
